### PR TITLE
Faster image load

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To list all import services for the application: `rake -T | grep import`
 To import the GuideCard records (takes about 3 minutes): `rake import:import_guide_cards`
 To import the SubGuideCard records (takes about 2 minutes): `rake import:import_sub_guide_cards`
 
-The CardImage records are the images that are included in the GuideCard and SubGuideCard records. There are 5,786,727 images. These take about 12 days to import.
+The CardImage records are the images that are included in the GuideCard and SubGuideCard records. There are 5,786,727 images. These are estimated to take about 1 day to import.
 
 To import the CardImage records: `rake import:import_card_images`
 

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -37,7 +37,7 @@ class CardImageLoadingService
   # returns something like
   # "2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif\n2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif\n"
   def s3_disk_list(disk)
-    s3_query = "aws s3 ls s3://puliiif-production/imagecat-disk#{disk}"
+    s3_query = "aws s3 ls s3://puliiif-production/imagecat-disk#{disk}-"
     `#{s3_query}`
   end
 

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -12,60 +12,40 @@ class CardImageLoadingService
   end
 
   def import
-    import_guide_card_images
-    import_sub_guide_images
+    (1..22).each { |disk| import_disk(disk) }
   end
 
-  # For each SubGuideCard, take its path and query s3 to get all of the image names
-  # for that path. For each image file, create a CardImage object with the path and
-  # image name.
-  def import_sub_guide_images
-    progressbar = progress_bar(SubGuideCard.count)
-    SubGuideCard.all.each do |sgc|
-      progressbar.increment
-      image_array(sgc.path).each do |file_name|
-        create_card_image(sgc, file_name)
-      end
+  def import_disk(disk)
+    disk_array(disk).each do |file_name|
+      find_or_create_card_image(file_name)
     end
-  end
-
-  def import_guide_card_images
-    progressbar = progress_bar(GuideCard.count)
-    GuideCard.all.each do |gc|
-      progressbar.increment
-      image_array(gc.path).each do |file_name|
-        create_card_image(gc, file_name)
-      end
-    end
-  end
-
-  # returns something like
-  # ["imagecat-disk9-0091-A3037-1358.0110.tif", "imagecat-disk9-0091-A3037-1358.0111.tif"]
-  def image_array(path)
-    s3_image_list(path).split("\n").map(&:split).map(&:last)
-  end
-
-  # returns something like
-  # "2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif\n2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif\n"
-  def s3_image_list(path)
-    s3_query = "aws s3 ls s3://puliiif-production/imagecat-disk#{path.tr('/', '-')}"
-    `#{s3_query}`
   end
 
   private
 
-  def create_card_image(sgc, file_name)
-    ci = CardImage.find_by(path: sgc.path, image_name: file_name)
+  # returns something like
+  # ["imagecat-disk9-0091-A3037-1358.0110.tif", "imagecat-disk9-0091-A3037-1358.0111.tif"]
+  def disk_array(disk)
+    s3_disk_list(disk).split("\n").map(&:split).map(&:last)
+  end
+
+  # returns something like
+  # "2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif\n2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif\n"
+  def s3_disk_list(disk)
+    s3_query = "aws s3 ls s3://puliiif-production/imagecat-disk#{disk}"
+    `#{s3_query}`
+  end
+
+  def find_or_create_card_image(file_name)
+    path = file_name.gsub('imagecat-disk', '').split('-')[0..-2].join('/')
+    ci = CardImage.find_by(path:, image_name: file_name)
     return if ci
 
-    ci = CardImage.new
-    ci.path = sgc.path
-    ci.image_name = file_name
-    ci.save
+    CardImage.create(path:, image_name: file_name)
   end
 
   def progress_bar(total)
-    ProgressBar.create(format: "\e[1;35m%t: |%B|\e[0m", total: total, output: progress_output)
+    ProgressBar.create(format: "\e[1;35m%t: |%B|\e[0m", total:, output: progress_output)
   end
 
   def progress_output

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -5,9 +5,10 @@ require 'ruby-progressbar/outputs/null'
 
 # Class for card image loading service
 class CardImageLoadingService
-  attr_reader :suppress_progress
+  attr_reader :logger, :suppress_progress
 
-  def initialize(suppress_progress: false)
+  def initialize(logger: nil, suppress_progress: false)
+    @logger = logger || Logger.new($stdout)
     @suppress_progress = suppress_progress
   end
 
@@ -16,7 +17,11 @@ class CardImageLoadingService
   end
 
   def import_disk(disk)
-    disk_array(disk).each do |file_name|
+    logger.info("Fetching disk #{disk} file list")
+    filenames = disk_array(disk)
+    progress = progress_bar(filenames.count)
+    filenames.each do |file_name|
+      progress.increment
       find_or_create_card_image(file_name)
     end
   end
@@ -45,7 +50,7 @@ class CardImageLoadingService
   end
 
   def progress_bar(total)
-    ProgressBar.create(format: "\e[1;35m%t: |%B|\e[0m", total:, output: progress_output)
+    ProgressBar.create(format: "%a %e %P% Loading: %c from %C", total: total, output: progress_output)
   end
 
   def progress_output

--- a/spec/services/card_image_loading_service_spec.rb
+++ b/spec/services/card_image_loading_service_spec.rb
@@ -3,7 +3,12 @@
 require 'rails_helper'
 
 describe CardImageLoadingService do
-  let(:card_image_loader) { described_class.new(suppress_progress: true) }
+  let(:card_image_loader) do
+    described_class.new(
+      logger: Logger.new(nil),
+      suppress_progress: true
+    )
+  end
   let(:guide_card_loader) do
     GuideCardLoadingService.new(
       csv_location: Rails.root.join('spec', 'fixtures', 'guide_card_fixture.csv'),

--- a/spec/services/card_image_loading_service_spec.rb
+++ b/spec/services/card_image_loading_service_spec.rb
@@ -22,43 +22,41 @@ describe CardImageLoadingService do
     )
   end
 
-  context 'new way' do
-    let(:s3_response_disk9) do
-      <<~HERE
-        2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif
-        2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif
-        2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3038-0000.0001.tif
-        2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3038-0000.0002.tif
-        2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3038-0000.0003.tif
-        2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3067-0000.0048.tif
-      HERE
-    end
-    let(:s3_response_disk14) do
-      <<~HERE
-        2023-07-19 14:39:38       3422 imagecat-disk14-0001-A1007-1358.0110.tif
-        2023-07-19 14:39:38       7010 imagecat-disk14-0001-A1007-1358.0111.tif
-        2023-07-19 14:39:38       7010 imagecat-disk14-0002-A1008-0000.0001.tif
-      HERE
-    end
-    before do
-      allow(card_image_loader).to receive(:s3_disk_list).with(anything).and_return('')
-      allow(card_image_loader).to receive(:s3_disk_list).with(9).and_return(s3_response_disk9)
-      allow(card_image_loader).to receive(:s3_disk_list).with(14).and_return(s3_response_disk14)
-    end
+  let(:s3_response_disk9) do
+    <<~HERE
+      2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif
+      2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif
+      2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3038-0000.0001.tif
+      2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3038-0000.0002.tif
+      2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3038-0000.0003.tif
+      2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3067-0000.0048.tif
+    HERE
+  end
+  let(:s3_response_disk14) do
+    <<~HERE
+      2023-07-19 14:39:38       3422 imagecat-disk14-0001-A1007-1358.0110.tif
+      2023-07-19 14:39:38       7010 imagecat-disk14-0001-A1007-1358.0111.tif
+      2023-07-19 14:39:38       7010 imagecat-disk14-0002-A1008-0000.0001.tif
+    HERE
+  end
+  before do
+    allow(card_image_loader).to receive(:s3_disk_list).with(anything).and_return('')
+    allow(card_image_loader).to receive(:s3_disk_list).with(9).and_return(s3_response_disk9)
+    allow(card_image_loader).to receive(:s3_disk_list).with(14).and_return(s3_response_disk14)
+  end
 
-    it 'creates CardImage database entries based on the s3 listing' do
-      card_image_loader.import
-      expect(CardImage.find_by(image_name: 'imagecat-disk14-0002-A1008-0000.0001.tif').path).to eq '14/0002/A1008'
-      expect(CardImage.count).to eq 9
-      guide_card_loader.import
-      sub_guide_card_loader.import
-      gc = GuideCard.find_by(path: '14/0001/A1007')
-      expect(CardImage.where(path: gc.path).count).to eq 2
-      sgc = SubGuideCard.find_by(path: '9/0091/A3038')
-      expect(CardImage.where(path: sgc.path).count).to eq 3
-      # If you reimport, it doesn't create duplicate rows
-      card_image_loader.import
-      expect(CardImage.count).to eq 9
-    end
+  it 'creates CardImage database entries based on the s3 listing' do
+    card_image_loader.import
+    expect(CardImage.find_by(image_name: 'imagecat-disk14-0002-A1008-0000.0001.tif').path).to eq '14/0002/A1008'
+    expect(CardImage.count).to eq 9
+    guide_card_loader.import
+    sub_guide_card_loader.import
+    gc = GuideCard.find_by(path: '14/0001/A1007')
+    expect(CardImage.where(path: gc.path).count).to eq 2
+    sgc = SubGuideCard.find_by(path: '9/0091/A3038')
+    expect(CardImage.where(path: sgc.path).count).to eq 3
+    # If you reimport, it doesn't create duplicate rows
+    card_image_loader.import
+    expect(CardImage.count).to eq 9
   end
 end

--- a/spec/services/card_image_loading_service_spec.rb
+++ b/spec/services/card_image_loading_service_spec.rb
@@ -1,17 +1,20 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'ruby-progressbar/outputs/null'
 
 describe CardImageLoadingService do
-  let(:cils) { described_class.new(progressbar: ProgressBar.create(output: ProgressBar::Outputs::Null)) }
+  let(:cils) { described_class.new(suppress_progress: true) }
   let(:gcls) do
-    GuideCardLoadingService.new(csv_location: Rails.root.join('spec', 'fixtures', 'guide_card_fixture.csv'),
-                                progressbar: ProgressBar.create(output: ProgressBar::Outputs::Null))
+    GuideCardLoadingService.new(
+      csv_location: Rails.root.join('spec', 'fixtures', 'guide_card_fixture.csv'),
+      progressbar: ProgressBar.create(output: ProgressBar::Outputs::Null)
+    )
   end
   let(:sgls) do
-    SubGuideLoadingService.new(csv_location: Rails.root.join('spec', 'fixtures', 'subguide_card_fixture.csv'),
-                               progressbar: ProgressBar.create(output: ProgressBar::Outputs::Null))
+    SubGuideLoadingService.new(
+      csv_location: Rails.root.join('spec', 'fixtures', 'subguide_card_fixture.csv'),
+      progressbar: ProgressBar.create(output: ProgressBar::Outputs::Null)
+    )
   end
   let(:s3_response) do
     "2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif\n2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif\n"
@@ -21,10 +24,6 @@ describe CardImageLoadingService do
     allow(cils).to receive(:s3_image_list).with(anything).and_return(s3_response)
     # Any card with a path of "sub" will not have any images
     allow(cils).to receive(:s3_image_list).with('sub').and_return('')
-  end
-
-  it 'can instantiate' do
-    expect(cils).to be_instance_of described_class
   end
 
   it 'imports all SubGuideCard images' do
@@ -50,12 +49,6 @@ describe CardImageLoadingService do
   it 'gets a list of images from s3' do
     image_list = cils.s3_image_list('9/0091/A3037')
     expect(image_list.split("\n").count).to eq 2
-  end
-
-  it 'displays ruby-progress bar during import' do
-    expect(cils.progressbar.to_h['percentage']).to eq 0
-    cils.import_sub_guide_images
-    expect(cils.progressbar.to_h['percentage']).to eq 100
   end
 
   it 'imports both GuideCard and SubGuideCard images' do


### PR DESCRIPTION
This improves performance in 2 ways:

1. Instead of running an `aws ls` per each resource in the database, we run it once per "disk" in the image filenames. This lets us call it 22 times, instead of 40 thousand times.

2. We just create the CardImage objects by parsing the file name string into the correct "path" value. This way we don't need to fetch each of the 40 thousand guide card objects out of the database.

This PR also changes the progress bar to a display an elapsed time, ETA, exact percent, and total.