### PR TITLE
Speed up GuideImage insert using insert_all

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,7 @@ Metrics/AbcSize:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - "app/services/card_image_loading_service.rb"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To list all import services for the application: `rake -T | grep import`
 To import the GuideCard records (takes about 3 minutes): `rake import:import_guide_cards`
 To import the SubGuideCard records (takes about 2 minutes): `rake import:import_sub_guide_cards`
 
-The CardImage records are the images that are included in the GuideCard and SubGuideCard records. There are 5,786,727 images. These are estimated to take about 1 day to import.
+The CardImage records are the images that are included in the GuideCard and SubGuideCard records. There are 5,780,170 images. These are estimated to take about 9 minutes to import.
 
 To import the CardImage records: `rake import:import_card_images`
 

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -26,16 +26,16 @@ class CardImageLoadingService
         end
       end.flat_map(&:wait)
       progress_bar.total = all_files.count
-      import_files(all_files)
+      import_files(all_files, barrier)
     ensure
       barrier.stop
     end
   end
 
-  def import_files(all_files)
+  def import_files(all_files, barrier)
     Sync do
       # Insert 10 batches at a time.
-      semaphore = Async::Semaphore.new(10)
+      semaphore = Async::Semaphore.new(10, parent: barrier)
       # insert_all in batches of 1000
       all_files.each_slice(1000).map do |slice|
         semaphore.async do

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -52,7 +52,8 @@ class CardImageLoadingService
       { path: path, image_name: file_name }
     end
     result = CardImage.insert_all(insert_slice)
-    progress_bar.progress += result.count
+    logger.info("Created #{result.count} rows")
+    progress_bar.progress += 1000
   end
 
   private

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -46,6 +46,7 @@ class CardImageLoadingService
   end
 
   def import_slice(slice)
+    logger.info("Importing slice")
     # Create an array of hashes that represent what we want to insert.
     insert_slice = slice.map do |file_name|
       path = file_name.gsub('imagecat-disk', '').split('-')[0..-2].join('/')

--- a/app/services/card_image_loading_service.rb
+++ b/app/services/card_image_loading_service.rb
@@ -62,9 +62,11 @@ class CardImageLoadingService
 
   # returns something like
   # "2023-07-19 14:39:38       3422 imagecat-disk9-0091-A3037-1358.0110.tif\n2023-07-19 14:39:38       7010 imagecat-disk9-0091-A3037-1358.0111.tif\n"
+  # :nocov:
   def s3_disk_list(disk)
     `aws s3 ls s3://puliiif-production/imagecat-disk#{disk}-`
   end
+  # :nocov:
 
   def progress_bar
     @progress_bar ||= ProgressBar.create(format: '%a %e %P% Loading: %c from %C', output: progress_output, total: 0, title: 'Image import')

--- a/db/migrate/20231012212118_add_card_image_unique_index.rb
+++ b/db/migrate/20231012212118_add_card_image_unique_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Adds a unique index for image_name to card_images so that `insert_all` for
+# bulk ingest will work.
+class AddCardImageUniqueIndex < ActiveRecord::Migration[7.0]
+  def change
+    add_index :card_images, :image_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_10_192642) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_12_212118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_192642) do
     t.text "image_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["image_name"], name: "index_card_images_on_image_name", unique: true
   end
 
   create_table "guide_cards", force: :cascade do |t|


### PR DESCRIPTION
Thanks to @hackartisan's work making the inserts and queries happen in parallel I was able to notice that despite significant import parallelism everything was still slower than we wanted, which implies that either the GIL was slowing things down or postgres was slow. For it to be the GIL it'd have to be all the Rails stuff in the way.

Insert_all bypasses all the rails stuff and just generates `INSERT RETURNING` statements that it hen executes. If we add a unique index then it won't create a record a second time. This bypasses validation and other rails bits, but we don't have any on this model.

I was having a very hard time getting the inserts to happen in parallel without it immediately sucking up all of Rails' connection pool, so I left the disk queries to be parallel (so much faster), but did `insert_all` synchronously. It's fast enough.

I just ran this on staging: 

```
Time: 00:07:43 Time: 00:07:43 100.00% Loading: 5780172 from 5780172

real    9m28.503s
```
```
irb(main):001:0> CardImage.all.count
=> 5780172
```