### PR TITLE
Pull trivy DB from AWS instead of ghcr.

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -77,6 +77,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.20.0
         id: runscanner
         continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: 'ghcr.io/pulibrary/imagecat-rails:${{ steps.meta.outputs.version }}'
           format: 'table'

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -20,6 +20,8 @@ jobs:
         uses: aquasecurity/trivy-action@0.20.0
         id: runscanner
         continue-on-error: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         with:
           image-ref: 'ghcr.io/pulibrary/imagecat-rails:main'
           format: 'table'


### PR DESCRIPTION
Should make the Trivy scans fail less.