### PR TITLE
Add permissions for creating issues, so dependabot PRs work.

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,4 +1,8 @@
 name: Create and publish a Docker image
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
 
 on:
   push:

--- a/.github/workflows/nightly-vuln-scanning.yml
+++ b/.github/workflows/nightly-vuln-scanning.yml
@@ -1,4 +1,8 @@
 name: Run nightly vulnerability check
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
 
 on:
   schedule:


### PR DESCRIPTION
GITHUB_TOKEN for dependabot is read-only, so can't create the container scan issue or comment.

See
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions