### PR TITLE
Don't add ruby-foreman package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl nginx postgresql-client ruby-foreman && \
+    apt-get install --no-install-recommends -y curl nginx postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # configure nginx


### PR DESCRIPTION
It pulls in debian's system ruby, which our scanner gets upset about.

The remaining gem vulnerabilities are from the base image's version of json/net-imap, and also we have a legit upgrade for net-imap.
